### PR TITLE
Allow access to the key and value in Element

### DIFF
--- a/type.go
+++ b/type.go
@@ -15,6 +15,16 @@ type Element struct {
 	value interface{}
 }
 
+// Key allows retrieval of the key for a given Element
+func (e *Element) Key() float64 {
+	return e.key
+}
+
+// Value allows retrieval of the value for a given Element
+func (e *Element) Value() interface{} {
+	return e.value
+}
+
 type SkipList struct {
 	elementNode
 	maxLevel       int


### PR DESCRIPTION
In order for this to be in any way useful, you need to be able to access the value of the element you retrieve.
This change makes the value accessible by exposing Element.Value() and the same for Key() as well.