### PR TITLE
add test showing data race - run with "go test -race"

### DIFF
--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -1,6 +1,7 @@
 package skiplist
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -153,5 +154,30 @@ func TestChangeProbability(t *testing.T) {
 	list.SetProbability(0.5)
 	if list.probability != 0.5 {
 		t.Fatal("failed to set new list probability value: expected 0.5, got", list.probability)
+	}
+}
+
+func TestConcurrency(t *testing.T) {
+	list := New()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		for i := 0; i < 100000; i++ {
+			list.Set(float64(i), i)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 100000; i++ {
+			list.Get(float64(i))
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	if list.length != 100000 {
+		t.Fail()
 	}
 }


### PR DESCRIPTION
This test demonstrates the data race I mentioned in #3 - the test by itself may not fail, but when run with `go test -race` data races are detected.

From [this](https://blog.golang.org/race-detector) official blog post on the race detector:
"It will not issue false positives, so take its warnings seriously."