### PR TITLE
quit loop earlier when get

### DIFF
--- a/skiplist.go
+++ b/skiplist.go
@@ -60,6 +60,10 @@ func (list *SkipList) Get(key float64) *Element {
 	var next *Element
 
 	for i := list.maxLevel - 1; i >= 0; i-- {
+		if next != nil && next == prev.next[i] {
+			return prev.next[i]
+		}
+		
 		next = prev.next[i]
 
 		for next != nil && key > next.key {


### PR DESCRIPTION
quit loop earlier when get

```
BenchmarkIncGet/get1-8         	  352358	      3883 ns/op	90745.84 MB/s	       0 B/op	       0 allocs/op
BenchmarkIncGet/get2-8         	 2053378	      1722 ns/op	1192243.30 MB/s	       0 B/op	       0 allocs/op
```