### PR TITLE
CBG-4351-prereq: Add support for sequence ranges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/couchbasedeps/fast-skiplist
 
 go 1.24.3
+
+require github.com/stretchr/testify v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/couchbasedeps/fast-skiplist
+
+go 1.24.3

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -76,18 +76,28 @@ func TestBasicIntCRUD(t *testing.T) {
 	elem, err := list.Set(SkippedSequenceEntry{Start: 10, End: 10})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(10), elem.key.Start)
+	assert.Equal(t, uint64(10), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 60, End: 60})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(60), elem.key.Start)
+	assert.Equal(t, uint64(60), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 30, End: 31})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(30), elem.key.Start)
+	assert.Equal(t, uint64(31), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 20, End: 20})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(20), elem.key.Start)
+	assert.Equal(t, uint64(20), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 90, End: 90})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(90), elem.key.Start)
+	assert.Equal(t, uint64(90), elem.key.End)
 	checkSanity(list, t)
 
 	// try set element that already exists in the list (30-31 exits so setting 30-30 should fail)
@@ -102,6 +112,8 @@ func TestBasicIntCRUD(t *testing.T) {
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 20, End: 20})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(20), elem.key.Start)
+	assert.Equal(t, uint64(20), elem.key.End)
 	checkSanity(list, t)
 
 	v1 := list.Get(SkippedSequenceEntry{Start: 10, End: 10})
@@ -268,14 +280,24 @@ func TestRemoveSeqFromRange(t *testing.T) {
 	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 5})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(5), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 8, End: 10})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(8), elem.key.Start)
+	assert.Equal(t, uint64(10), elem.key.End)
+
+	assert.Equal(t, int64(8), list.GetNumSequencesInList())
 
 	// Remove a sequence from the first range
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 8, End: 8})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(8), elem.key.Start)
+	assert.Equal(t, uint64(8), elem.key.End)
+
+	assert.Equal(t, int64(7), list.GetNumSequencesInList())
 
 	// Check if the first range is updated correctly
 	elem = list.Get(SkippedSequenceEntry{Start: 8, End: 8})
@@ -289,25 +311,35 @@ func TestRemoveSeqFromRange(t *testing.T) {
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 10, End: 10})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(10), elem.key.Start)
+	assert.Equal(t, uint64(10), elem.key.End)
+
+	assert.Equal(t, int64(6), list.GetNumSequencesInList())
 
 	elem = list.Get(SkippedSequenceEntry{Start: 9, End: 9})
 	require.NotNil(t, elem)
 	assert.Equal(t, uint64(9), elem.key.Start)
 	assert.Equal(t, uint64(9), elem.key.End)
 
-	assert.Equal(t, 2, list.Length)
+	assert.Equal(t, 2, list.GetLength())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 9, End: 9})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(9), elem.key.Start)
+	assert.Equal(t, uint64(9), elem.key.End)
 
-	assert.Equal(t, 1, list.Length)
+	assert.Equal(t, 1, list.GetLength())
+	assert.Equal(t, int64(5), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 3, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(3), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 
-	assert.Equal(t, 2, list.Length)
+	assert.Equal(t, 2, list.GetLength())
+	assert.Equal(t, int64(4), list.GetNumSequencesInList())
 
 	elem = list.Get(SkippedSequenceEntry{Start: 1, End: 1})
 	require.NotNil(t, elem)
@@ -329,12 +361,18 @@ func TestRemoveFromThreeRange(t *testing.T) {
 	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 
-	assert.Equal(t, 1, list.Length)
+	assert.Equal(t, 1, list.GetLength())
+	assert.Equal(t, int64(3), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 2, End: 2})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(2), elem.key.Start)
+	assert.Equal(t, uint64(2), elem.key.End)
+	assert.Equal(t, int64(2), list.GetNumSequencesInList())
 
 	elem = list.Get(SkippedSequenceEntry{Start: 1, End: 1})
 	require.NotNil(t, elem)
@@ -349,7 +387,7 @@ func TestRemoveFromThreeRange(t *testing.T) {
 	elem = list.Get(SkippedSequenceEntry{Start: 2, End: 2})
 	require.Nil(t, elem)
 
-	assert.Equal(t, 2, list.Length)
+	assert.Equal(t, 2, list.GetLength())
 }
 
 func TestRemoveRange(t *testing.T) {
@@ -357,18 +395,30 @@ func TestRemoveRange(t *testing.T) {
 	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
+	assert.Equal(t, int64(3), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 1, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
+	assert.Equal(t, int64(0), list.GetNumSequencesInList())
 
 	elem, err = list.Set(SkippedSequenceEntry{Start: 1, End: 10})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(10), elem.key.End)
+	assert.Equal(t, int64(10), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 1, End: 5})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(5), elem.key.End)
+	assert.Equal(t, int64(5), list.GetNumSequencesInList())
 
 	elem = list.Get(SkippedSequenceEntry{Start: 8, End: 8})
 	require.NotNil(t, elem)
@@ -387,15 +437,22 @@ func TestGetFrontElem(t *testing.T) {
 		t.Fatal("Front element should be nil")
 	}
 
+	// all items below are being added are contiguous so will extend the same element in the list
 	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 1})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(1), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 2, End: 2})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(2), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 3, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 
 	elem = list.Front()
 	require.NotNil(t, elem)
@@ -409,17 +466,24 @@ func TestRemoveRangeAcrossElements(t *testing.T) {
 	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 	elem, err = list.Set(SkippedSequenceEntry{Start: 5, End: 6})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(5), elem.key.Start)
+	assert.Equal(t, uint64(6), elem.key.End)
 
-	assert.Equal(t, 2, list.Length)
+	assert.Equal(t, 2, list.GetLength())
+	assert.Equal(t, int64(5), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 1, End: 5})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
 
-	assert.Equal(t, 1, list.Length)
+	assert.Equal(t, 1, list.GetLength())
+	assert.Equal(t, int64(1), list.GetNumSequencesInList())
+
 	elem = list.Get(SkippedSequenceEntry{Start: 1, End: 1})
 	require.Nil(t, elem)
 
@@ -435,7 +499,8 @@ func TestRemoveRangeAcrossElements(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, elem)
 
-	assert.Equal(t, 3, list.Length)
+	assert.Equal(t, 3, list.GetLength())
+	assert.Equal(t, int64(3), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 6, End: 10})
 	require.NoError(t, err)
@@ -446,7 +511,22 @@ func TestRemoveRangeAcrossElements(t *testing.T) {
 	elem = list.Get(SkippedSequenceEntry{Start: 10, End: 10})
 	require.Nil(t, elem)
 
-	assert.Equal(t, 0, list.Length)
+	assert.Equal(t, 0, list.GetLength())
+	assert.Equal(t, int64(0), list.GetNumSequencesInList())
+
+	elem, err = list.Set(SkippedSequenceEntry{Start: 1, End: 3})
+	require.NoError(t, err)
+	require.NotNil(t, elem)
+	elem, err = list.Set(SkippedSequenceEntry{Start: 5, End: 6})
+	require.NoError(t, err)
+	require.NotNil(t, elem)
+
+	elem, err = list.Remove(SkippedSequenceEntry{Start: 2, End: 6})
+	require.NoError(t, err)
+	require.NotNil(t, elem)
+
+	assert.Equal(t, 1, list.GetLength())
+	assert.Equal(t, int64(1), list.GetNumSequencesInList())
 }
 
 func TestCompact(t *testing.T) {
@@ -461,9 +541,15 @@ func TestCompact(t *testing.T) {
 
 	num := list.CompactList(time.Now().Unix(), 100)
 	assert.Equal(t, int64(6), num)
-	assert.Equal(t, 0, list.Length)
+	assert.Equal(t, 0, list.GetLength())
+	assert.Equal(t, int64(0), list.GetNumSequencesInList())
 
 	assert.Nil(t, list.backElem)
+
+	num = list.CompactList(time.Now().Unix(), 100)
+	assert.Equal(t, int64(0), num)
+	assert.Equal(t, 0, list.GetLength())
+	assert.Equal(t, int64(0), list.GetNumSequencesInList())
 }
 
 func TestRemovingFromLastElem(t *testing.T) {
@@ -472,37 +558,58 @@ func TestRemovingFromLastElem(t *testing.T) {
 	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 3, Timestamp: 0})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 
-	assert.Equal(t, 1, list.Length)
+	assert.Equal(t, 1, list.GetLength())
 	assert.Equal(t, uint64(1), list.backElem.key.Start)
 	assert.Equal(t, uint64(3), list.backElem.key.End)
+	assert.Equal(t, int64(3), list.GetNumSequencesInList())
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 1, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
-	assert.Equal(t, 0, list.Length)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
+	assert.Equal(t, 0, list.GetLength())
 	assert.Nil(t, list.backElem)
+
+	assert.Equal(t, int64(0), list.GetNumSequencesInList())
+	assert.Equal(t, 0, list.GetLength())
 
 	// add elem back
 	elem, err = list.Set(SkippedSequenceEntry{Start: 1, End: 3, Timestamp: 0})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 
 	// remove subset
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 2, End: 2})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
-	assert.Equal(t, 2, list.Length)
+	assert.Equal(t, uint64(2), elem.key.Start)
+	assert.Equal(t, uint64(2), elem.key.End)
+	assert.Equal(t, 2, list.GetLength())
 	assert.Equal(t, uint64(3), list.backElem.key.Start)
 	assert.Equal(t, uint64(3), list.backElem.key.End)
+	assert.Equal(t, int64(2), list.GetNumSequencesInList())
 }
 
 func TestRemoveItemNotInList(t *testing.T) {
 	list := New()
 
-	elem, err := list.Set(SkippedSequenceEntry{Start: 1, End: 3})
+	// remove item form empty list
+	elem, err := list.Remove(SkippedSequenceEntry{Start: 1, End: 1})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "skiplist empty")
+	require.Nil(t, elem, "Expected nil when removing from an empty list")
+
+	elem, err = list.Set(SkippedSequenceEntry{Start: 1, End: 3})
 	require.NoError(t, err)
 	require.NotNil(t, elem)
+	assert.Equal(t, uint64(1), elem.key.Start)
+	assert.Equal(t, uint64(3), elem.key.End)
 
 	elem, err = list.Remove(SkippedSequenceEntry{Start: 4, End: 4})
 	require.Error(t, err)


### PR DESCRIPTION
Adds support for ranges for skipped sequence storage